### PR TITLE
🐛 fix: add BETTER_AUTH_SECRET env var to vitest config to resolve CI unhandled error

### DIFF
--- a/apps/neo-fujimatsu/vitest.config.ts
+++ b/apps/neo-fujimatsu/vitest.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
           include: ["./test/e2e/**/*.spec.ts"],
           name: "e2e",
           testTimeout: 15000,
+          env: {
+            BETTER_AUTH_SECRET: "test-secret",
+          },
         },
       },
     ],


### PR DESCRIPTION
# Summary

The CI was failing with an unhandled `BetterAuthError` because `BETTER_AUTH_SECRET` was not set in the vitest e2e test environment.

## Target Package

`apps/neo-fujimatsu`

## Changes (What)

- Added `env.BETTER_AUTH_SECRET` to the e2e project config in `vitest.config.ts`

## Related Issues

- Closes #
- Related to #

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (please describe below)

## Checklist

- [ ] All checks pass