### PR TITLE
⚙️ Change minimum release age from 7 days to 1 day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 7
+      default-days: 1
     commit-message:
       prefix: "⬆️ "
       prefix-development: "⬆️ "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "⬆️ "
       prefix-development: "⬆️ "

--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,7 @@
 engine-strict=true
 ignore-scripts=true
 audit=true
-min-release-age=604800
+min-release-age=86400
 audit-level=high
 save-exact=true
 allow-git=root

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
 linker = "isolated"
 exact = true
-minimumReleaseAge = 604800
+minimumReleaseAge = 86400


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# Summary

Unify the minimum release age setting across `.npmrc`, `bunfig.toml`, and `dependabot.yml` from 7 days to 1 day.

## Target Package

Root configuration files (`.npmrc`, `bunfig.toml`, `.github/dependabot.yml`)

## Changes (What)

- `.npmrc`: `min-release-age=604800` → `min-release-age=86400`
- `bunfig.toml`: `minimumReleaseAge = 604800` → `minimumReleaseAge = 86400`
- `.github/dependabot.yml`: `cooldown.default-days: 7` → `cooldown.default-days: 1`

## Related Issues

- Closes #
- Related to #

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (please describe below)

## Checklist

- [x] All checks pass

<!-- I want to review in Japanese. -->
