### PR TITLE
✅ test(ura-roppoh): remove setTimeout from OIDC client VRT tests

### DIFF
--- a/apps/ura-roppoh/test/visual-regression/pages/oidc-client.spec.tsx
+++ b/apps/ura-roppoh/test/visual-regression/pages/oidc-client.spec.tsx
@@ -129,7 +129,6 @@ describe("VRT oidc-client page - create dialog", async () => {
     const { container } = await render(<Stub initialEntries={[PATH]} />, {
       wrapper: withNuqsTestingAdapter({ searchParams: { dialog: "create" } }),
     });
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Assert
     await expect(container).toMatchScreenshot();
@@ -160,7 +159,6 @@ describe("VRT oidc-client page - update dialog - with client data", async () => 
         searchParams: { dialog: "edit", client_id: "client-1-id" },
       }),
     });
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Assert
     await expect(container).toMatchScreenshot();
@@ -188,7 +186,6 @@ describe("VRT oidc-client page - update dialog - skeleton loading", async () => 
         searchParams: { dialog: "edit", client_id: "client-1-id" },
       }),
     });
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Assert
     await expect(container).toMatchScreenshot();
@@ -219,7 +216,6 @@ describe("VRT oidc-client page - delete dialog - with client data", async () => 
         searchParams: { dialog: "delete", client_id: "client-1-id" },
       }),
     });
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Assert
     await expect(container).toMatchScreenshot();
@@ -247,7 +243,6 @@ describe("VRT oidc-client page - delete dialog - skeleton loading", async () => 
         searchParams: { dialog: "delete", client_id: "client-1-id" },
       }),
     });
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Assert
     await expect(container).toMatchScreenshot();


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# Summary

Remove `setTimeout` calls from OIDC client visual regression tests. These arbitrary delays are unnecessary since `vitest-browser-react`'s `render` handles async rendering correctly.

## Target Package

<!-- Which package is this PR related to? -->

- `apps/ura-roppoh`

## Changes (What)

- Removed `await new Promise((resolve) => setTimeout(resolve, 100))` from the following test suites in `test/visual-regression/pages/oidc-client.spec.tsx`:
  - `VRT oidc-client page - create dialog`
  - `VRT oidc-client page - update dialog - with client data`
  - `VRT oidc-client page - update dialog - skeleton loading`
  - `VRT oidc-client page - delete dialog - with client data`
  - `VRT oidc-client page - delete dialog - skeleton loading`

## Related Issues

- Closes #
- Related to #

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (please describe below)

## Checklist

- [x] All checks pass

<!-- I want to review in Japanese. -->