### PR TITLE
✅ Add VRT tests for all pages in neo-fujimatsu (light & dark themes)

### DIFF
--- a/apps/neo-fujimatsu/test/vrt/404/msw.handler.ts
+++ b/apps/neo-fujimatsu/test/vrt/404/msw.handler.ts
@@ -1,0 +1,3 @@
+import type { RequestHandler } from "msw";
+
+export const handlers = [] satisfies RequestHandler[];

--- a/apps/neo-fujimatsu/test/vrt/404/page.spec.tsx
+++ b/apps/neo-fujimatsu/test/vrt/404/page.spec.tsx
@@ -1,0 +1,27 @@
+import { expect } from "@playwright/test";
+
+import { testWithMswMock } from "../helpers/test-with-msw-mock";
+import { setTheme } from "../helpers/theme";
+import { handlers } from "./msw.handler";
+
+testWithMswMock(handlers)("vrt /404 dark", async ({ page }) => {
+  // Arrange
+  await setTheme({ page, theme: "dark" });
+
+  // Act
+  await page.goto("/not-found", { waitUntil: "networkidle" });
+
+  // Assert
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});
+
+testWithMswMock(handlers)("vrt /404 light", async ({ page }) => {
+  // Arrange
+  await setTheme({ page, theme: "light" });
+
+  // Act
+  await page.goto("/not-found", { waitUntil: "networkidle" });
+
+  // Assert
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});

--- a/apps/neo-fujimatsu/test/vrt/consent/msw.handler.ts
+++ b/apps/neo-fujimatsu/test/vrt/consent/msw.handler.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from "msw";
+import type { RequestHandler } from "msw";
+
+export const handlers = [
+  http.get("*/api/auth/get-session", () => {
+    return HttpResponse.json({
+      user: {
+        id: "user-1",
+        name: "Test User",
+        email: "test@example.com",
+        emailVerified: true,
+        image: null,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      session: {
+        id: "session-1",
+        userId: "user-1",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        ipAddress: null,
+        userAgent: null,
+      },
+    });
+  }),
+  http.get("*/api/auth/oauth2/get-client", () => {
+    return HttpResponse.json({
+      client_id: "test-client-id",
+      client_name: "Test Application",
+    });
+  }),
+] satisfies RequestHandler[];

--- a/apps/neo-fujimatsu/test/vrt/consent/page.spec.tsx
+++ b/apps/neo-fujimatsu/test/vrt/consent/page.spec.tsx
@@ -1,0 +1,30 @@
+import { expect } from "@playwright/test";
+
+import { testWithMswMock } from "../helpers/test-with-msw-mock";
+import { setTheme } from "../helpers/theme";
+import { handlers } from "./msw.handler";
+
+const CONSENT_URL =
+  "/consent?client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&cancel_uri=http%3A%2F%2Flocalhost%3A3000%2Fcancel&scope=profile+email";
+
+testWithMswMock(handlers)("vrt /consent dark", async ({ page }) => {
+  // Arrange
+  await setTheme({ page, theme: "dark" });
+
+  // Act
+  await page.goto(CONSENT_URL, { waitUntil: "networkidle" });
+
+  // Assert
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});
+
+testWithMswMock(handlers)("vrt /consent light", async ({ page }) => {
+  // Arrange
+  await setTheme({ page, theme: "light" });
+
+  // Act
+  await page.goto(CONSENT_URL, { waitUntil: "networkidle" });
+
+  // Assert
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});

--- a/apps/neo-fujimatsu/test/vrt/sign-in/page.spec.tsx
+++ b/apps/neo-fujimatsu/test/vrt/sign-in/page.spec.tsx
@@ -4,9 +4,20 @@ import { testWithMswMock } from "../helpers/test-with-msw-mock";
 import { setTheme } from "../helpers/theme";
 import { handlers } from "./msw.handler";
 
-testWithMswMock(handlers)("vrt /sign-in", async ({ page }) => {
+testWithMswMock(handlers)("vrt /sign-in dark", async ({ page }) => {
   // Arrange
   await setTheme({ page, theme: "dark" });
+
+  // Act
+  await page.goto("/sign-in", { waitUntil: "networkidle" });
+
+  // Assert
+  await expect(page).toHaveScreenshot({ fullPage: true });
+});
+
+testWithMswMock(handlers)("vrt /sign-in light", async ({ page }) => {
+  // Arrange
+  await setTheme({ page, theme: "light" });
 
   // Act
   await page.goto("/sign-in", { waitUntil: "networkidle" });


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# Summary

Add Visual Regression Testing (VRT) for all pages in the `neo-fujimatsu` app. Each page is tested in both **dark** and **light** themes.

## Target Package

<!-- Which package is this PR related to? -->

`apps/neo-fujimatsu`

## Changes (What)

- Add light theme test to the existing `/sign-in` VRT spec (renamed dark test for clarity)
- Add VRT tests for `/404` page (dark & light)
- Add VRT tests for `/consent` page (dark & light), with MSW handlers mocking `GET /api/auth/get-session` and `GET /api/auth/oauth2/get-client`

## Related Issues

- Closes #
- Related to #

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (please describe below)

## Checklist

- [ ] All checks pass

<!-- I want to review in Japanese. -->